### PR TITLE
Added message ID and received date

### DIFF
--- a/src/main/java/org/subethamail/wiser/Wiser.java
+++ b/src/main/java/org/subethamail/wiser/Wiser.java
@@ -134,7 +134,13 @@ public class Wiser implements SimpleMessageListener
 			log.debug("Creating message from data with " + bytes.length + " bytes");
 
 		// create a new WiserMessage.
-		this.messages.add(new WiserMessage(this, from, recipient, bytes));
+		WiserMessage mess = new WiserMessage(this, from, recipient, bytes);
+		if (this.messages.add(mess)) {
+			mess.setId( this.messages.size());
+		}
+		else {
+			log.error( "Failed to add new message from "+from+" to list");
+		}
 	}
 
 	/**
@@ -156,6 +162,21 @@ public class Wiser implements SimpleMessageListener
 	public List<WiserMessage> getMessages()
 	{
 		return this.messages;
+	}
+	
+	/**
+	 * Returns WiserMessage identified with ID.
+	 * <p>
+	 * Message is currently identified by position in messages array.
+	 * Because arrays are 0 based, we need to subtract 1 to get the proper index
+	 */
+	public WiserMessage getMessage( long id )
+	{
+		if (id > 0 && id <= this.messages.size()) {
+			int index = (int) id-1;
+			return this.messages.get(index);
+		}
+		return null;
 	}
 
 	/**

--- a/src/main/java/org/subethamail/wiser/WiserMessage.java
+++ b/src/main/java/org/subethamail/wiser/WiserMessage.java
@@ -2,6 +2,7 @@ package org.subethamail.wiser;
 
 import java.io.ByteArrayInputStream;
 import java.io.PrintStream;
+import java.util.Date;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
@@ -14,10 +15,14 @@ import javax.mail.internet.MimeMessage;
  */
 public class WiserMessage
 {
+	static final long NO_ID = -1L;
+	
 	byte[] messageData;
 	Wiser wiser;
 	String envelopeSender;
 	String envelopeReceiver;
+	Date   receivedAt;
+	long   id = NO_ID;
 
 	WiserMessage(Wiser wiser, String envelopeSender, String envelopeReceiver, byte[] messageData)
 	{
@@ -25,6 +30,8 @@ public class WiserMessage
 		this.envelopeSender = envelopeSender;
 		this.envelopeReceiver = envelopeReceiver;
 		this.messageData = messageData;
+		this.receivedAt = new Date();
+		this.id = NO_ID; // id is set by Wiser.deliver
 	}
 
 	/**
@@ -36,6 +43,22 @@ public class WiserMessage
 		return new MimeMessage(this.wiser.getSession(), new ByteArrayInputStream(this.messageData));
 	}
 
+	/**
+	 * Get message identifier
+	 */
+
+	public long getId() {
+		return this.id;
+	}
+	
+	/**
+	 * Set message identifier
+	 */
+
+	public void setId( long id ) {
+		this.id = id;
+	}
+	
 	/**
 	 * Get's the raw message DATA.
 	 */
@@ -58,6 +81,14 @@ public class WiserMessage
 	public String getEnvelopeSender()
 	{
 		return this.envelopeSender;
+	}
+	
+	/**
+	 * Get's date the mail was received
+	 */
+	public Date getReceivedAt()
+	{
+		return this.receivedAt;
 	}
 
 	/**


### PR DESCRIPTION
To build a Java version of mailcatcher (test-tool that serves as an SMTP server, keeps all mail and provides a webinterface to browse messages received, see http://mailcatcher.me/), that can be deployed as a .war, I needed messages to have an ID (number) and a reception date. So I added those two attributes. Plus a method to retrieve a message by ID.
The mailcatcher lookalike will be in a separate project.